### PR TITLE
Fix no_password_engine typo in the generator.

### DIFF
--- a/lib/generators/nopassword/install/install_generator.rb
+++ b/lib/generators/nopassword/install/install_generator.rb
@@ -16,7 +16,7 @@ module Nopassword
     end
 
     def copy_migration_file
-      rake "nopassword_engine:install:migrations"
+      rake "no_password_engine:install:migrations"
     end
   end
 end


### PR DESCRIPTION
When running the `install` generator, an error will be raised:

```bash
$ bundle exec rails generate nopassword:install
   identical  app/controllers/email_authentications_controller.rb
       exist  app/views/email_authentication_mailer
   identical  app/views/email_authentication_mailer/notification_email.html.erb
   identical  app/views/email_authentication_mailer/notification_email.html.txt
       exist  app/views/email_authentications
   identical  app/views/email_authentications/edit.html.erb
   identical  app/views/email_authentications/new.html.erb
       route  resource :email_authentication
        rake  nopassword_engine:install:migrations
rake aborted!
Don't know how to build task 'nopassword_engine:install:migrations' (See the list of available tasks with `rake --tasks`)
Did you mean?  no_password_engine:install:migrations

(See full trace by running task with --trace)
```

Upon checking available rake tasks:

```bash
$ rake --tasks | grep _engine
rake no_password_engine:install:migrations          # Copy migrations from no_password_engine to application
```

We can identify this typo. 

This commit fixes this typo - and addresses #2 