### PR TITLE
Loosen jwt dependency to allow 3.x

### DIFF
--- a/nopassword.gemspec
+++ b/nopassword.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rails", ">= 7.0.1"
   spec.add_dependency "zeitwerk", "~> 2.0"
   spec.add_dependency "http", "~> 5.1"
-  spec.add_dependency "jwt", "~> 2.8"
+  spec.add_dependency "jwt", ">= 2.8", "< 4.0"
   spec.add_dependency "uri-builder", "~> 0.1.5"
   spec.add_development_dependency "rspec-rails"
 end


### PR DESCRIPTION
## Summary

Widen `jwt` constraint from `~> 2.8` (`>= 2.8, < 3.0`) to `>= 2.8, < 4.0`.

`jwt` 3.2.0 patches [CVE-2026-45363](https://www.cve.org/CVERecord?id=CVE-2026-45363) (empty-key HMAC bypass). The only `jwt` usage in nopassword is Apple OAuth (`RS256` decode + `ES256` encode), which is fully compatible with the jwt 3.x API. Tested against jwt 3.2.0.

Without this change, applications that depend on nopassword cannot upgrade to the patched jwt version.